### PR TITLE
Create sample-claude-text.json

### DIFF
--- a/gen-ai/sample-claude-text.json
+++ b/gen-ai/sample-claude-text.json
@@ -1,0 +1,128 @@
+{
+  "variable": [
+    {
+      "value": "https://api.anthropic.com/v1/messages",
+      "key": "api.url"
+    },
+    {
+      "value": "<your-prompt-here>",
+      "current": "",
+      "key": "textInput"
+    },
+    {
+      "value": "claude-3-opus-20240229",
+      "key": "llm"
+    },
+    {
+      "value": "1",
+      "current": "",
+      "key": "temp"
+    },
+    {
+      "value": "<anthropic-api-key>",
+      "current": "",
+      "key": "apiKey"
+    }
+  ],
+  "protocolProfileBehavior": {},
+  "item": [
+    {
+      "name": "Generate a response from the model with the provided text input",
+      "request": {
+        "header": [
+          {
+            "description": "",
+            "disabled": false,
+            "value": "{{apiKey}}",
+            "key": "x-api-key"
+          },
+          {
+            "description": "",
+            "value": "2023-06-01",
+            "key": "anthropic-version"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "file": "",
+          "urlencoded": [],
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          },
+          "raw": "{\n    \"model\": \"{{llm}}\",\n    \"max_tokens\": 1024,\n    \"temperature\": {{temp}},\n    \"messages\": [\n        {\"role\": \"user\", \"content\": [\n            {\"type\": \"text\", \"text\": \"{{textInput}}\"}\n        ]}\n    ]\n}",
+          "formdata": [],
+          "graphql": ""
+        },
+        "method": "POST",
+        "auth": {
+          "type": "noauth"
+        },
+        "url": {
+          "host": [
+            "{{api.url}}"
+          ],
+          "raw": "{{api.url}}",
+          "query": [
+            {
+              "description": "",
+              "value": "",
+              "enabled": true,
+              "key": ""
+            }
+          ]
+        }
+      },
+      "event": [
+        {
+          "mablVariables": [
+            {
+              "description": "Response generated from the model",
+              "assertTarget": "JSONBody",
+              "variableName": "response",
+              "bodyPath": "content[0].text"
+            }
+          ],
+          "mablAssertions": [
+            {
+              "assertType": "Equals",
+              "description": "Status is 200",
+              "assertTarget": "Status",
+              "value": "200"
+            }
+          ],
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "// __MABL_GENERATED__ Do not edit below this line",
+              "pm.environment.set(\"response\", JSON.stringify(_.get(pm.response.json(), pm.variables.replaceIn('content[0].text')))?.replace(/^\"(.+(?=\"$))\"$/, '$1'));",
+              "pm.test(\"Status is 200\", function () { pm.response.to.have.status(parseInt(\"200\")); });"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": []
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": []
+      }
+    }
+  ],
+  "info": {
+    "name": "Sample - Claude | text",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  }
+}


### PR DESCRIPTION
This version includes an assertion on the response status code and a variable created from the response.

It does not variables to configure "top_p" or "top_k" values - not sure if we want to add those.